### PR TITLE
CI checks out the repo using a GH app token

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,3 +1,4 @@
+---
 name: update
 
 on:
@@ -11,9 +12,9 @@ on:
         required: false
 
 env:
-  VAULT_ADDR: https://vault.eng.aserto.com/  
+  VAULT_ADDR: https://vault.eng.aserto.com/
   GO_VERSION: "1.23"
-  GO_LANGCI_LINT_VERSION: "v1.61.0"  
+  GO_LANGCI_LINT_VERSION: "v1.61.0"
   CONSOLE_VERSION: ${{ inputs.version }}
 
 jobs:
@@ -21,31 +22,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CODEGEN_APP_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_KEY }}
+      -
+        name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       -
         name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}          
-      - 
-        name: Read Configuration
-        uses: hashicorp/vault-action@v3
-        id: vault
-        with:
-          url: https://vault.eng.aserto.com/
-          token: ${{ secrets.VAULT_TOKEN }}
-          secrets: |
-            kv/data/github  "SSH_PRIVATE_KEY"     | SSH_PRIVATE_KEY;
-            kv/data/github  "READ_WRITE_TOKEN"    | READ_WRITE_TOKEN;
-      - 
-        name: Setup git
-        run: |
-          mkdir -p $HOME/.ssh
-          umask 0077 && echo -e "${SSH_PRIVATE_KEY}" > $HOME/.ssh/id_rsa
-          ssh-keyscan github.com >> $HOME/.ssh/known_hosts
-          git config --global url."git@github.com:".insteadOf https://github.com/
-          git config --global user.email "github-bot@aserto.com"
-          git config --global user.name "Aserto Bot"
+          go-version: ${{ env.GO_VERSION }}
       -
         name: Update static files
         run: |


### PR DESCRIPTION
The app is allowed to bypass branch protection rules in the repo. This setup ensures that branch protection is enforced for human contributors, but the automated workflow can generate code and commit it to main.